### PR TITLE
Add Hosted Payment Page (iframe & redirect) sample to catalog

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -35,6 +35,7 @@ Integration samples and examples for Global Payments API Platform, organized by 
 - [Authorization with Delayed/Future Capture](https://github.com/globalpayments-samples/online-payments-auth-and-delayed-capture)
 - [Google Pay](https://github.com/globalpayments-samples/google-pay-payments)
 - [Pay by Link](https://github.com/globalpayments-samples/pay-by-link)
+- [Hosted Payment Page (iframe & redirect)](https://github.com/globalpayments-samples/hpp-links-iframe-redirect)
 - [Payments and Reporting (PHP)](https://github.com/globalpayments-samples/php-payments-and-reporting)
 - [Save and Reuse Payments](https://github.com/globalpayments-samples/save-and-reuse-payment-methods)
 - [Network Tokenization](https://github.com/globalpayments-samples/network-tokenization)


### PR DESCRIPTION
## What

Adds the new **[hpp-links-iframe-redirect](https://github.com/globalpayments-samples/hpp-links-iframe-redirect)** sample to the org profile catalog, under **Integration Samples → Online Payments** (next to *Pay by Link*, since both are built on the GP API Links API).

## Why

This is a new GP API sample demonstrating the **Hosted Payment Page** flow — the merchant server creates a `HOSTED_PAYMENT_PAGE` link via the Links API, and the customer pays on a Global-Payments-hosted page shown either in an **iframe** or via a full-page **redirect**. Card data, 3-D Secure, saved cards, wallets, DCC and APMs are all handled on the hosted page, so no card fields touch the merchant server. It ships identical implementations across five backends: **.NET, Java, Node.js, PHP, and Python**.

## Reviewer notes — how this reaches the live samples site

The [samples portal](https://globalpayments-samples.github.io) is now driven **live from the GitHub org REST API**, so it has no static project list to edit. For the project card to render on the site, the repo itself needs a `description` and topics set (it currently has neither). Those are prepared and will be applied **once this PR is approved**, so the card goes live only after sign-off.

Proposed repo metadata (for reference):
- **Description:** `GP API Hosted Payment Page sample — create a HOSTED_PAYMENT_PAGE link via the Links API and take payment in an iframe or full-page redirect, across five backends.`
- **Topics:** `lang-dotnet`, `lang-java`, `lang-nodejs`, `lang-php`, `lang-python`, `hosted-payment-page`, `links-api`, `3d-secure`, `iframe`, `redirect`, `webhooks`